### PR TITLE
Fixed main logo not going to Open XDMoD site for modules

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -17,7 +17,7 @@
 <body>
   <div id="page-container">
     <div id="page-header">
-      <a href="index.html"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/xdmod_logo.png" alt="XDMoD" /></a>
+      <a href="http://open.xdmod.org"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/xdmod_logo.png" alt="XDMoD" /></a>
       <span class="maintitle">{% if site.xdmod_module_name %}{{ site.xdmod_module_name }} Module{% endif %}</span>
     </div>
     <a href="{{ site.github_url }}"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>


### PR DESCRIPTION
This fixes the issue by hard-coding the main Open XDMoD site URL.