### PR TITLE
Mobile Open XDMoD Website

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -104,9 +104,9 @@
         {{ content }}
       </div>
       <div class="clear"></div>
-    </div>
-    <div id="page-footer" role="contentinfo">
+      <div id="page-footer" role="contentinfo">
       <a href="https://www.buffalo.edu/ccr" target="_blank"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/ccr_logo.png" alt="Center for Computational Research"/></a>
+    </div>
     </div>
   </div>
 </body>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -65,12 +65,14 @@
       {% if page.style %}<a href="https://www.nsf.gov"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/NSF_4-Color_bitmap_Logo.png" alt="National Science Foundation" class='nsflogo' /></a>{% endif %}
       <a href="http://open.xdmod.org"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/xdmod_logo.png" alt="XDMoD" class='xdmodlogo' /></a>
       <span class="maintitle">{% if site.xdmod_module_name %}{{ site.xdmod_module_name }} Module{% else %}Open XDMoD{% endif %} {{page.version}}</span>
+      <label class="hamb" for="side-menu"><span class="hamb-line"></span></label>
     </div>
     {% if page.is_dev %}
     <a href="{{ site.github_url }}"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
     {% endif %}
     <div id="page-body">
       <div class="clear"></div>
+      <input class="side-menu" type="checkbox" id="side-menu"/>
       <div id="page-menu" role="navigation">
           {% if table_of_contents %}<div class="page-menu-toc">{{ table_of_contents }}</div>{% endif %}
           {% if site.version_list %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -45,6 +45,7 @@
 {% capture style_sheet %}{% if page.style %}{{ page.style }}{% else %}main{% endif %}{% endcapture %}
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if site.xdmod_module_name %}{{site.xdmod_module_name}} {{doc_path}}{% else %}Open XDMoD{% if page.title != 'Open XDMoD' %} - {{ page.title }}{% endif %}{% endif %}</title>
   <link rel="icon" type="image/x-icon" href="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/favicon.ico" />
   <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}{{ site.theme_subdir }}/assets/css/{{style_sheet}}.css" />

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -603,26 +603,26 @@ div.page-menu-toc {
     }
 }
 
-@media only screen and (max-width: 700px) {
+@media only screen and (max-width: 850px) {
 
     .side-menu:checked ~ #page-menu{
-    max-width: 100%;
+        max-width: 100%;
     }
 
     .side-menu:checked ~ #page-content{
-    z-index: -2;
-    position: fixed;
+        z-index: -2;
+        position: fixed;
     }
 
     .side-menu:checked ~ #page-footer{
-    display: none; 
+        display: none; 
     }
 
-        #page-container {
-            width:100%;
-        }
+    #page-container {
+        width:100%;
+    }
     
-        #page-header{
+    #page-header{
         background-color: #fff;
         position: fixed;
         height: 80px;
@@ -637,40 +637,39 @@ div.page-menu-toc {
        font-size: 6vw;
     }
 
-     #page-header img {
-    position: relative;
+    #page-header img {
+        position: relative;
     }
 
     .hamb-line {
-    background: rgb(0, 51, 153);
-    display: block;
-    height: 4px;  
-    position: absolute; 
-    left: 15px;
-    top: 40px;
-    width: 35px;
- 
-}
+        background: rgb(0, 51, 153);
+        display: block;
+        height: 4px;  
+        position: absolute; 
+        left: 15px;
+        top: 40px;
+        width: 35px; 
+    }
     
-  #page-content {
-    margin: 0;
-    width: 100%;
-}
+    #page-content {
+        margin: 0;
+        width: 100%;
+    }
     
     h1, #page-content h2, h3{
         margin-left: 15px;
     }
     
     p {
-    margin: 0px 10px 30px 15px;
-    font-size: 16px;
+        margin: 0px 10px 30px 15px;
+        font-size: 16px;
     }
 
     #page-menu {
-    margin: 0px;
-    padding: 0px;
-    border-left: 0;
-    border-top: 0;
+        margin: 0px;
+        padding: 0px;
+        border-left: 0;
+        border-top: 0;
     }
 
     #page-menu{
@@ -699,8 +698,9 @@ div.page-menu-toc {
         text-align: center;
         font-size: 2.6em;
         padding-top: 10px;
-}
-    #page-menu li{
+    }
+
+    #page-menu li {
         text-align: center;
         list-style-type: none;
         font-size: 1.8em;
@@ -708,17 +708,17 @@ div.page-menu-toc {
     }
 
     #page-menu li:hover {
-    background-color: #ced5dd;
+        background-color: #ced5dd;
     }
 
     #page-menu a{
-    text-decoration: none;
-    display: block;
-    line-height: 1.2
-     }
+        text-decoration: none;
+        display: block;
+        line-height: 1.2
+    }
 
     #page-menu li a:hover {
-    color: #039;
+        color: #039;
     }
 
     #page-menu ul ul {
@@ -727,50 +727,54 @@ div.page-menu-toc {
     }
 
     div.page-menu-toc {
-    border-bottom: 0px solid #039;
-    margin-bottom: 0;
-    padding-bottom: 0;
+        border-bottom: 0px solid #039;
+        margin-bottom: 0;
+        padding-bottom: 0;
     }
 
     #page-body {
-    width: 100%;
-    margin-top:80px;
+        width: 100%;
+        margin-top:80px;
     }
 
      p img {
         display: inline-block;
         width: 100%;
-        }
+     }
 
     table {
         margin: 15px;
     }
 
-    code {;
-    font-size: 100%;
-}
+    code {
+        font-size: 100%;
+    }
+
+   pre {
+       margin-left: 15px;
+    }
     
-    pre.highlight {
-    width: auto;
-    padding: auto;
-    margin: 15px 15px 15px 15px;
-}
+   pre.highlight {
+        width: auto;
+        padding: auto;
+        margin: 15px 15px 15px 15px;
+   }
 
    .language-plaintext.highlighter-rouge{
-   word-wrap: break-word;
-}
-
+       word-wrap: break-word;
+   }
+ 
 }
 
 @media only screen and (max-width: 610px){
 
     #page-header .xdmodlogo {
-    height: 30pt;
-}
+        height: 30pt;
+    }
 
-#page-header .nsflogo {
-    height: 50pt;
- }
+    #page-header .nsflogo {
+        height: 50pt;
+    }
 }
 
 @media only screen and (max-width: 545px){
@@ -780,11 +784,10 @@ div.page-menu-toc {
     }
 
     #page-header img {
-    position: absolute;
-    float: right;
-    bottom: 1px;
-    
-    }
+        position: absolute;
+        float: right;
+        bottom: 1px;
+     }
 
     #page-header {
         position: absolute;
@@ -798,20 +801,19 @@ div.page-menu-toc {
     }
 
     #page-header .xdmodlogo {
-    left: 150px;
-    height: 28pt;   
-    
-}
+        left: 150px;
+        height: 28pt;   
+    }
 
-      #page-header .nsflogo {
-    left:65px;
-}
+    #page-header .nsflogo {
+        left:65px;
+    }
 
-      .hamb {
-   position:absolute;
-    bottom: 1px;
-    padding: 40px 30px;
-}
+    .hamb {
+        position:absolute;
+        bottom: 1px;
+        padding: 40px 30px;
+    }
 
     #page-body {
         margin-top: 135px;
@@ -825,8 +827,8 @@ div.page-menu-toc {
 }
 
 
-@media (min-width: 701px) {
+@media (min-width: 851px) {
      .hamb-line {
-        display: none;
+         display: none;
      }
 }

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -675,10 +675,10 @@ div.page-menu-toc {
 
     #page-menu{
         width: 400px;
-        height: 100%;
+        height: 100vh;
         position: absolute;
         background-color: #e0e0e0;
-        overflow: scroll;
+        overflow: auto;
         top: 80px;
         left: 0px; 
         right: 0px;
@@ -697,14 +697,14 @@ div.page-menu-toc {
     
      #page-menu h2{
         text-align: center;
-        font-size: 3.0em;
-        padding-top: 15px;
+        font-size: 2.6em;
+        padding-top: 10px;
 }
     #page-menu li{
         text-align: center;
         list-style-type: none;
-        font-size: 2.0em;
-        padding: 10px
+        font-size: 1.8em;
+        padding: 8px
     }
 
     #page-menu li:hover {
@@ -793,11 +793,10 @@ div.page-menu-toc {
     left:65px;
 }
 
-    #page-header .hamb-line {
-    position: absolute;
-    top: 90px;
-    right: 150px;
-        
+      .hamb {
+   position:absolute;
+    bottom: 1px;
+    padding: 40px 30px;
 }
 
     #page-body {

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -761,6 +761,10 @@ div.page-menu-toc {
 
 @media only screen and (max-width: 545px){
 
+    h1{
+        font-size: 1.8em;
+    }
+
     #page-header img {
     position: absolute;
     float: right;
@@ -769,6 +773,7 @@ div.page-menu-toc {
     }
 
     #page-header {
+        position: absolute;
         height: 130px;
     }
     
@@ -779,7 +784,6 @@ div.page-menu-toc {
     }
 
     #page-header .xdmodlogo {
-    
     left: 150px;
     height: 28pt;   
     

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -710,6 +710,11 @@ div.page-menu-toc {
     color: #039;
     }
 
+    #page-menu ul ul {
+        background-color: #e7e7e7;
+        font-size: 77%
+    }
+
     #page-body {
     width: 100%;
     margin-top:80px;

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -756,6 +756,10 @@ div.page-menu-toc {
     margin: 15px 15px 15px 15px;
 }
 
+   .language-plaintext.highlighter-rouge{
+   word-wrap: break-word;
+}
+
 }
 
 @media only screen and (max-width: 610px){

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -656,7 +656,7 @@ div.page-menu-toc {
     width: 100%;
 }
     
-    h1, #page-content h2{
+    h1, #page-content h2, h3{
         margin-left: 15px;
     }
     

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -665,8 +665,8 @@ div.page-menu-toc {
 
     #page-menu{
         width: 400px;
-        height: 100vh;
-        position: absolute;
+        height: 100vw;
+        position: fixed;
         background-color: #e0e0e0;
         overflow: auto;
         top: 80px;

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -665,7 +665,7 @@ div.page-menu-toc {
 
     #page-menu{
         width: 400px;
-        height: 100vw;
+        height: 100vh;
         position: fixed;
         background-color: #e0e0e0;
         overflow: auto;
@@ -773,7 +773,7 @@ div.page-menu-toc {
      span.maintitle {
         left: 0px;
         top: 0px;
-        font-size: 2.4em;
+        font-size: 9vw;
     }
 
     #page-header .xdmodlogo {
@@ -798,6 +798,7 @@ div.page-menu-toc {
     
     #page-menu{
         top:130px;
+        position: absolute;
     }
 
 }

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -715,6 +715,12 @@ div.page-menu-toc {
         font-size: 77%
     }
 
+    div.page-menu-toc {
+    border-bottom: 0px solid #039;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    }
+
     #page-body {
     width: 100%;
     margin-top:80px;

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -729,18 +729,14 @@ div.page-menu-toc {
         margin: 15px;
     }
 
-    code {
-    font-family: monospace, sans-serif;
-    font-size: 135%;
+    code {;
+    font-size: 100%;
 }
     
     pre.highlight {
-    background-color: #202020;
-    overflow: auto;
-    color: #e0e0e0;
-    width: 100%;
-    border-radius: 0.5ex;
-    padding: 0.2em;
+    width: auto;
+    padding: auto;
+    margin: 15px 15px 15px 15px;
 }
 
 }

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -248,19 +248,6 @@ div.page-menu-toc {
     display: none;
 }
 
-.side-menu:checked ~ #page-menu{
-    max-width: 100%;
-}
-
-.side-menu:checked ~ #page-content{
-    z-index: -2;
-    position: fixed;
-}
-
-.side-menu:checked ~ #page-footer{
-    display: none; 
-}
-
 
 /* end hamburger style */
 
@@ -611,11 +598,25 @@ div.page-menu-toc {
 /* Responsive */
 
 @media screen and (max-width: 1040px){
-#page-content {
-    width: 700px;
+    #page-content {
+        width: 700px;
+    }
 }
-}
+
 @media only screen and (max-width: 700px) {
+
+    .side-menu:checked ~ #page-menu{
+    max-width: 100%;
+    }
+
+    .side-menu:checked ~ #page-content{
+    z-index: -2;
+    position: fixed;
+    }
+
+    .side-menu:checked ~ #page-footer{
+    display: none; 
+    }
 
         #page-container {
             width:100%;
@@ -712,8 +713,9 @@ div.page-menu-toc {
 
     #page-menu a{
     text-decoration: none;
-    display: block
-    }
+    display: block;
+    line-height: 1.2
+     }
 
     #page-menu li a:hover {
     color: #039;

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -210,6 +210,62 @@ div.page-menu-toc {
     color: white;
 }
 
+/* Start hamburger style */
+
+.hamb{
+    cursor: pointer;
+    float: left;   
+    padding: 40px 30px;
+}
+
+.hamb-line {
+    background: rgb(0, 51, 153);
+    display: block;
+    height: 4px;   
+    position: relative;
+    width: 48px;
+ 
+}
+
+.hamb-line::before,
+.hamb-line::after{
+    background: rgb(0, 51, 153);
+    content: '';   
+    display: block;
+    height: 100%;  
+    position: absolute;
+    transition: all .2s ease-out;
+    width: 100%;
+}
+.hamb-line::before{
+    top: 10px;
+}
+.hamb-line::after{
+    top: -10px;   
+}
+
+.side-menu {
+    display: none;
+}
+
+.side-menu:checked ~ #page-menu{
+    max-width: 100%;
+}
+.side-menu:checked ~ .hamb .hamb-line {
+    background: transparent;
+}
+.side-menu:checked ~ .hamb .hamb-line::before {
+    transform: rotate(-45deg);
+    top:0;
+}
+.side-menu:checked ~ .hamb .hamb-line::after {
+    transform: rotate(45deg);
+    top:0;
+}
+
+/* end hamburger style */
+
+
 .highlight pre {
     background-color: #202020;
 }
@@ -551,4 +607,152 @@ div.page-menu-toc {
     position: relative;
     top: 0px;
     width: 100%;
+}
+
+/* Responsive */
+
+@media screen and (max-width: 1040px){
+#page-content {
+    width: 700px;
+}
+}
+@media only screen and (max-width: 700px) {
+
+        #page-container {
+            width:100%;
+        }
+    
+        #page-header{
+        background-color: #fff;
+        position: fixed;
+        height: 80px;
+        width: 100%;
+        z-index: 2;
+    }
+
+    span.maintitle {
+       position: absolute;
+       right: 15px;
+       top: 10px;
+       font-size: 2.4em;
+    }
+
+     #page-header img {
+    position: relative;
+    }
+
+    .hamb-line {
+    background: rgb(0, 51, 153);
+    display: block;
+    height: 4px;  
+    position: absolute; 
+    left: 15px;
+    top: 40px;
+    width: 35px;
+ 
+}
+    
+  #page-content {
+    margin: 0;
+    width: 100%;
+}
+    
+    h1, #page-content h2{
+        margin-left: 15px;
+    }
+    
+    p {
+    margin: 0px 10px 30px 15px;
+    font-size: 16px;
+    }
+
+    #page-menu {
+    margin: 0px;
+    padding: 0px;
+    border-left: 0;
+    border-top: 0;
+    }
+
+    #page-menu{
+        width: 400px;
+        height: 100%;
+        position: absolute;
+        background-color: #e0e0e0;
+        overflow: scroll;
+        top: 80px;
+        left: 0px; 
+        right: 0px;
+        border-bottom: 0px;
+        padding-bottom: 0px;
+        box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.7), 20px 30px 20px 0 rgba(0, 0, 0, 0.10);
+    }
+    
+    #page-menu{
+        border: 0;
+        margin-bottom: 0em;
+        padding-bottom: 0px;
+        max-width: 0px;
+        transition: max-width .2s cubic-bezier(0.4, 0, 1, 1);
+    }
+    
+     #page-menu h2{
+        text-align: center;
+        font-size: 3.0em;
+        padding-top: 15px;
+}
+    #page-menu li{
+        text-align: center;
+        list-style-type: none;
+        font-size: 2.0em;
+        padding: 10px
+    }
+
+    #page-menu li:hover {
+    background-color: #ced5dd;
+    }
+
+    #page-menu a{
+    text-decoration: none;
+    display: block
+    }
+
+    #page-menu li a:hover {
+    color: #039;
+    }
+
+    #page-body {
+    width: 100%;
+    margin-top:80px;
+    }
+
+    table {
+        margin: 15px;
+    }
+
+    code {
+    font-family: monospace, sans-serif;
+    font-size: 135%;
+}
+    
+    pre.highlight {
+    background-color: #202020;
+    overflow: auto;
+    color: #e0e0e0;
+    width: 100%;
+    border-radius: 0.5ex;
+    padding: 0.2em;
+}
+
+}
+
+@media only screen and (max-width: 610px){
+     span.maintitle {
+        font-size: 2.0em;
+    }
+}
+
+@media (min-width: 701px) {
+     .hamb-line {
+        display: none;
+     }
 }

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -746,10 +746,54 @@ div.page-menu-toc {
 }
 
 @media only screen and (max-width: 610px){
-     span.maintitle {
-        font-size: 2.0em;
+          span.maintitle {
+        font-size: 2.1em;
     }
+
+    #page-header .xdmodlogo {
+    height: 30pt;
 }
+
+#page-header .nsflogo {
+    height: 50pt;
+ }
+}
+
+@media only screen and (max-width: 545px){
+
+    #page-header img {
+    position: absolute;
+    float: right;
+    bottom: 1px;
+    
+    }
+
+    #page-header {
+        height: 130px;
+    }
+    
+     span.maintitle {
+        left: 0px;
+        top: 0px;
+        font-size: 2.4em;
+    }
+
+    #page-header .xdmodlogo {
+    
+    left: 150px;
+    height: 28pt;   
+    
+}
+
+    #page-header .hamb-line {
+    position: absolute;
+    top: 90px;
+    right: 150px;
+        
+}
+
+}
+
 
 @media (min-width: 701px) {
      .hamb-line {

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -251,17 +251,7 @@ div.page-menu-toc {
 .side-menu:checked ~ #page-menu{
     max-width: 100%;
 }
-.side-menu:checked ~ .hamb .hamb-line {
-    background: transparent;
-}
-.side-menu:checked ~ .hamb .hamb-line::before {
-    transform: rotate(-45deg);
-    top:0;
-}
-.side-menu:checked ~ .hamb .hamb-line::after {
-    transform: rotate(45deg);
-    top:0;
-}
+
 
 /* end hamburger style */
 
@@ -634,7 +624,7 @@ div.page-menu-toc {
        position: absolute;
        right: 15px;
        top: 10px;
-       font-size: 2.4em;
+       font-size: 6vw;
     }
 
      #page-header img {
@@ -742,9 +732,6 @@ div.page-menu-toc {
 }
 
 @media only screen and (max-width: 610px){
-          span.maintitle {
-        font-size: 2.1em;
-    }
 
     #page-header .xdmodlogo {
     height: 30pt;

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -715,6 +715,11 @@ div.page-menu-toc {
     margin-top:80px;
     }
 
+     p img {
+        display: inline-block;
+        width: 100%;
+        }
+
     table {
         margin: 15px;
     }

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -789,12 +789,24 @@ div.page-menu-toc {
     
 }
 
+      #page-header .nsflogo {
+    left:65px;
+}
+
     #page-header .hamb-line {
     position: absolute;
     top: 90px;
     right: 150px;
         
 }
+
+    #page-body {
+        margin-top: 135px;
+    }
+    
+    #page-menu{
+        top:130px;
+    }
 
 }
 

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -252,6 +252,15 @@ div.page-menu-toc {
     max-width: 100%;
 }
 
+.side-menu:checked ~ #page-content{
+    z-index: -2;
+    position: fixed;
+}
+
+.side-menu:checked ~ #page-footer{
+    display: none; 
+}
+
 
 /* end hamburger style */
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -193,3 +193,7 @@ span.maintitle
     top: 0px;
     width: 100%;
 }
+
+.side-menu {
+    display: none;
+}


### PR DESCRIPTION
Test webpages hosted on my [GitHub Pages](https://thanickcruz.github.io/xdmod/10.0/)

# Description
**Desktop version.** 
- Content width reduces below width 1040px.

**Mobile version.**
- Side menu becomes hamburger menu at and below width 850px.
- Content text fits to viewport.
- Logos and header text readjust according to screen width.
- Moved the div with id #page-footer to be sibling of #page-content. (allowed the subsequent-sibling combinator ~ to function properly)
- Made code blocks legible and scrollable.

# Context and Motivation
- The current Open XDMoD website is not user-friendly on mobile. (Illegible text, requires zooming in, visually unflattering)
- Website does not pass Google's mobile-friendly test, which may be preventing indexing of the latest site.

# Tests Performed
- Collected feedback from other team members
- Manually clicked through each page on various mobile devices
- Utilized Chrome and Safari dev tools for visual aid
- Mobile pages pass Google's [mobile-friendly test](https://search.google.com/test/mobile-friendly).