### PR TITLE
Update dependency version numbers to current versions.

### DIFF
--- a/xdmod-jekyll-theme.gemspec
+++ b/xdmod-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "xdmod-jekyll-theme"
-  spec.version       = "0.1.0"
+  spec.version       = "0.1.1"
   spec.authors       = ["The XDMoD Team"]
   spec.email         = ["ccr-xdmod-help@buffalo.edu"]
 
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(_layouts|assets|LICENSE|README.md)/i}) }
 
-  spec.add_development_dependency "jekyll", "~> 3.2"
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "jekyll", "~> 3.9"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Keep dependabot happy even though this file is ignored by guthub pages).