### PR TITLE
Update Marker Indentation

### DIFF
--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -192,7 +192,7 @@ div.page-menu-toc {
 .page-menu-toc ul {
     margin: 0;
     margin-bottom: 1em;
-    padding: 0;
+    padding: 1ex;
     list-style-position: inside;
     display: block;
     line-height: 140%;
@@ -224,18 +224,18 @@ div.page-menu-toc {
 .hamb-line {
     background: rgb(0, 51, 153);
     display: block;
-    height: 4px;   
+    height: 4px;
     position: relative;
     width: 48px;
- 
+
 }
 
 .hamb-line::before,
 .hamb-line::after{
     background: rgb(0, 51, 153);
-    content: '';   
+    content: '';
     display: block;
-    height: 100%;  
+    height: 100%;
     position: absolute;
     transition: all .2s ease-out;
     width: 100%;
@@ -244,7 +244,7 @@ div.page-menu-toc {
     top: 10px;
 }
 .hamb-line::after{
-    top: -10px;   
+    top: -10px;
 }
 
 .side-menu {
@@ -662,13 +662,13 @@ div .warning a {
     }
 
     .side-menu:checked ~ #page-footer{
-        display: none; 
+        display: none;
     }
 
     #page-container {
         width:100%;
     }
-    
+
     #page-header{
         background-color: #fff;
         position: absolute;
@@ -693,22 +693,22 @@ div .warning a {
     .hamb-line {
         background: rgb(0, 51, 153);
         display: block;
-        height: 4px;  
-        position: absolute; 
+        height: 4px;
+        position: absolute;
         left: 15px;
         top: 35px;
-        width: 35px; 
+        width: 35px;
     }
-    
+
     #page-content {
         margin: 0;
         width: 100%;
     }
-    
+
     h1, #page-content h2, h3{
         margin-left: 15px;
     }
-    
+
     p {
         margin: 0px 10px 30px 15px;
         font-size: 16px;
@@ -728,13 +728,13 @@ div .warning a {
         background-color: #e0e0e0;
         overflow: auto;
         top: 140px;
-        left: 0px; 
+        left: 0px;
         right: 0px;
         border-bottom: 0px;
         padding-bottom: 0px;
         box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.7), 20px 30px 20px 0 rgba(0, 0, 0, 0.10);
     }
-    
+
     #page-menu{
         border: 0;
         margin-bottom: 0em;
@@ -742,7 +742,7 @@ div .warning a {
         max-width: 0px;
         transition: max-width .2s cubic-bezier(0.4, 0, 1, 1);
     }
-    
+
      #page-menu h2{
         text-align: center;
         font-size: 2.6em;
@@ -807,7 +807,7 @@ div .warning a {
    pre {
        margin-left: 15px;
     }
-    
+
    pre.highlight {
         width: auto;
         padding: auto;
@@ -817,7 +817,7 @@ div .warning a {
    .language-plaintext.highlighter-rouge{
        word-wrap: break-word;
    }
- 
+
 }
 
 @media only screen and (max-width: 545px){
@@ -836,7 +836,7 @@ div .warning a {
         position: absolute;
         height: 130px;
     }
-    
+
      span.maintitle {
         text-align: center;
         line-height: 25px;
@@ -849,7 +849,7 @@ div .warning a {
     #page-header .xdmodlogo {
         left: 150px;
         top: 63px;
-        height: 25pt;   
+        height: 25pt;
     }
 
     #page-header .nsflogo {
@@ -866,7 +866,7 @@ div .warning a {
     #page-body {
         margin-top: 135px;
     }
-    
+
     #page-menu{
         top:130px;
         position: absolute;

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -192,7 +192,7 @@ div.page-menu-toc {
 .page-menu-toc ul {
     margin: 0;
     margin-bottom: 1em;
-    padding: 1ex;
+    padding: 0.5ex;
     list-style-position: inside;
     display: block;
     line-height: 140%;


### PR DESCRIPTION
This PR edits the indentation markers for subitems and subsubitems. Prior to this change there was no indentation between subitems and subsubitems. My editor also cleaned up a bunch of whitespace.

Documentation for the following modules are changed:
#### Open XDMoD
![image](https://github.com/ubccr/xdmod-jekyll-theme/assets/51850219/c6c7e20b-8eb2-40d6-bff9-44b01561957f)

#### Job Performance Module
![image](https://github.com/ubccr/xdmod-jekyll-theme/assets/51850219/75a85432-934d-474e-8968-5cdb1e162d32)

#### Application Kernels
![image](https://github.com/ubccr/xdmod-jekyll-theme/assets/51850219/b57ed495-cbf0-4134-a259-8829cf1152da)

The mobile menu is unaffected by these changes.