### PR TITLE
Swap order of `page.menu_markdown` and `site.version_list`.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -75,7 +75,14 @@
       <div class="clear"></div>
       <input class="side-menu" type="checkbox" id="side-menu"/>
       <div id="page-menu" role="navigation">
-          {% if table_of_contents %}<div class="page-menu-toc">{{ table_of_contents }}</div>{% endif %}
+          <div class="page-menu-toc">
+            {% if table_of_contents %}
+              {{ table_of_contents }}
+            {% elsif page.menu_markdown %}
+              {% capture menu_markdown %}{% include {{page.menu_markdown}} %}{% endcapture %}
+              {{ menu_markdown | markdownify }}
+            {% endif %}
+          </div>
           {% if site.version_list %}
             {% if site.latest_version == page.version %}
                 {% if site.version_list.size > 1 %}
@@ -106,10 +113,6 @@
             {% endfor %}
             </ul>
          {% endif %}
-        {% if page.menu_markdown %}
-            {% capture menu_markdown %}{% include {{page.menu_markdown}} %}{% endcapture %}
-            {{ menu_markdown | markdownify }}
-        {% endif %}
       </div>
       <div id="page-content" role="main">
         {% if doc_path %} <h1>{{ doc_path }}</h1> {% else %} <h1>{{ page.title }}</h1> {% endif %}


### PR DESCRIPTION
Currently, on pages that have `page.menu_markdown` set, such as https://open.xdmod.org/8.0/index.html, in the menu on the left, the version list appears above the menu markdown:

![Screen Shot 2024-02-05 at 6 29 55 PM](https://github.com/ubccr/xdmod-jekyll-theme/assets/31246768/e7c4b989-9bab-4a14-875a-bb897221021c)

This is a swapped order from what appears on pages that do not have `page.menu_markdown` set, such as https://open.xdmod.org/10.5/index.html:

![Screen Shot 2024-02-05 at 7 11 44 PM](https://github.com/ubccr/xdmod-jekyll-theme/assets/31246768/362e726d-25e5-4e11-9524-e7f3113cc310)

This PR moves the `page.menu_markdown` into the `page-menu-toc` div so that it appears above the version list with a line in between (the line requires updating the old pages to use the `effervescence` style, which is done in https://github.com/ubccr/xdmod/pull/1811, https://github.com/ubccr/xdmod-supremm/pull/370 and https://github.com/ubccr/xdmod-appkernels/pull/103).