### PR TITLE
Fix "no longer supported" link.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -61,7 +61,7 @@
 </head>
 <body>
   <div id="page-container">
-    {% unless site.version_list contains page.version %} <div class="not-supported-banner"><center> This version is <a href='/{{site.latest_version}}/support.html'>no longer supported</a>. The latest version is <a href="/{{site.latest_version}}/">Open XDMoD {{site.latest_sw_version}}</a>. </center></div> {% endunless %}
+    {% unless site.version_list contains page.version %} <div class="not-supported-banner"><center> This version is <a href='https://open.xdmod.org/{{site.latest_version}}/support.html'>no longer supported</a>. The latest version is <a href="/{{site.latest_version}}/">Open XDMoD {{site.latest_sw_version}}</a>. </center></div> {% endunless %}
     <div id="page-header" role="banner">
       {% if page.style %}<a href="https://www.nsf.gov"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/NSF_4-Color_bitmap_Logo.png" alt="National Science Foundation" class='nsflogo' /></a>{% endif %}
       <a href="http://open.xdmod.org"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/xdmod_logo.png" alt="XDMoD" class='xdmodlogo' /></a>


### PR DESCRIPTION
## Description
Currently, on the module sites for unsupported versions (e.g., https://supremm.xdmod.org/10.0/, https://appkernels.xdmod.org/10.0/, https://ondemand.xdmod.org/10.0/), the "no longer supported" link at the top is broken; it is pointing to a `support.html` page that does not exist in the module sites.

This PR fixes the link to point to the support page of the latest version of the open.xdmod.org site.

## Tests performed
I tested this locally on my laptop for each of the sites (`xdmod`, `supremm`, `appkernels`, and `ondemand`) in a cloned directory of the `gh-pages` branch of the site:
1. Edit `.gitmodules` to change `ubccr` to `aaronweeden`.
1. Run the following commands:
    ```
    git submodule init
    git submodule update --remote
    git -C xdmod-jekyll-theme switch fix-no-longer-supported-link
    bundle update
    bundle update --bundler
    bundle install
    bundle add webrick
    bundle exec jekyll serve
    ```
1. Browse to http://127.0.0.1:4000/10.0/
1. Click the "no longer supported" link and confirm it redirects to https://open.xdmod.org/10.5/support.html.