### PR TITLE
Add banner for old (but still supported) versions.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -61,7 +61,13 @@
 </head>
 <body>
   <div id="page-container">
-    {% unless site.version_list contains page.version %} <div class="not-supported-banner"><center> This version is <a href='https://open.xdmod.org/{{site.latest_version}}/support.html'>no longer supported</a>. The latest version is <a href="/{{site.latest_version}}/">Open XDMoD {{site.latest_sw_version}}</a>. </center></div> {% endunless %}
+    {% if site.latest_version != page.version %}
+      {% if site.version_list contains page.version %}
+        <div class="not-latest-banner"><center> This is an old version. The latest version is <a href="/{{site.latest_version}}/">Open XDMoD {{site.latest_sw_version}}</a>. </center></div>
+      {% else %}
+        <div class="not-supported-banner"><center> This version is <a href='https://open.xdmod.org/{{site.latest_version}}/support.html'>no longer supported</a>. The latest version is <a href="/{{site.latest_version}}/">Open XDMoD {{site.latest_sw_version}}</a>. </center></div>
+      {% endif %}
+    {% endif %}
     <div id="page-header" role="banner">
       {% if page.style %}<a href="https://www.nsf.gov"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/NSF_4-Color_bitmap_Logo.png" alt="National Science Foundation" class='nsflogo' /></a>{% endif %}
       <a href="http://open.xdmod.org"><img src="{{ site.baseurl }}{{ site.theme_subdir }}/assets/images/xdmod_logo.png" alt="XDMoD" class='xdmodlogo' /></a>

--- a/assets/css/effervescence.css
+++ b/assets/css/effervescence.css
@@ -590,7 +590,13 @@ div.page-menu-toc {
     color: #438dc4;
 }
 
-/* for unsupported versions */
+/* for old and unsupported versions */
+.not-latest-banner{
+    background-color:#EED202;
+    position: relative;
+    top: 0px;
+    width: 100%;
+}
 .not-supported-banner{
     background-color:#EF9A9A;
     position: relative;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -186,7 +186,13 @@ span.maintitle
     padding: 10px;
 }
 
-/* for unsupported versions */
+/* for old and unsupported versions */
+.not-latest-banner{
+    background-color:#EED202;
+    position: relative;
+    top: 0px;
+    width: 100%;
+}
 .not-supported-banner{
     background-color:#EF9A9A;
     position: relative;


### PR DESCRIPTION
This PR adds a banner at the top of the page for pages that are still supported but are not the latest version:

![Screenshot 2024-10-24 at 11 58 55 AM](https://github.com/user-attachments/assets/4954586c-1e1b-45e6-ad0d-be6363fc80ac)
